### PR TITLE
Horizontally align .talk-card's

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -338,7 +338,7 @@ article.event h2 {
   margin: 0;
 }
 .talk-card {
-  margin: 5rem 0 0 max(5vw, 2rem);
+  margin: 5rem 0 max(5vw, 2rem);
   position: relative;
 }
 .talk-card .headshot {


### PR DESCRIPTION
I discovered that on the events single pages, `.talk-card`'s would display additional margins to the left, offsetting them to the right. I wasn't sure if this was deliberate.

![screenshot showing additional margin on the left](https://user-images.githubusercontent.com/4201323/126358745-9bb2e2d4-7271-4777-933f-01397f3a48f3.png)

Removing the additional zero in the shorthand Property sets this as `margin-inline-end` instead, resulting in the `.talk-card`'s aligning to the center horizontally:

![screenshot showing the elements aligned to the horizontal center](https://user-images.githubusercontent.com/4201323/126358835-6a39da0c-e882-4855-a51d-69e09f532a3b.png)
