### PR TITLE
Make sure RSS feed entry elements aren't HTML escaped

### DIFF
--- a/src/rss.njk
+++ b/src/rss.njk
@@ -23,7 +23,7 @@ permalink: feed.xml
 
     {# build `entry` elements #}
     {% set entryElements %}
-      {{ entryElements }}
+      {{ entryElements|safe }}
       <entry>
         <title>{{ event.title }}</title>
         <link href="https://11tymeetup.dev/events/{{ event.slug.current }}"/>


### PR DESCRIPTION
Fix for "RSS feed show all events" issue 
https://github.com/Eleventy-Meetup/website/issues/7

Resolves #9 