### PR TITLE
Improve “convert to local time” functionality

### DIFF
--- a/src/_includes/event-long.njk
+++ b/src/_includes/event-long.njk
@@ -18,14 +18,20 @@
 
 <script>
   function convertTime() {
-    const timeNodes = document.querySelectorAll('time')
+    const timeNodes = document.querySelectorAll("time");
 
-    timeNodes.forEach(node => {
-      const date = new Date(node.dateTime)
-      const newLocaleString = date.toLocaleString([],{timeStyle:"long", dateStyle: "medium"})
-      node.innerHTML = newLocaleString;
-    })
+    timeNodes.forEach((node) => {
+      const date = new Date(node.dateTime);
+      const newLocaleString = date.toLocaleString([], {
+        timeStyle: "long",
+        dateStyle: "medium",
+      });
+      node.textContent = newLocaleString;
+    });
+
+    button.remove();
   }
 
-  document.querySelector('#convert-time').addEventListener('click', convertTime)
+  const button = document.querySelector("#convert-time");
+  button.addEventListener("click", convertTime);
 </script>

--- a/src/_includes/featured-event.njk
+++ b/src/_includes/featured-event.njk
@@ -19,14 +19,20 @@
 
 <script>
   function convertTime() {
-    const timeNodes = document.querySelectorAll('time')
+    const timeNodes = document.querySelectorAll("time");
 
-    timeNodes.forEach(node => {
-      const date = new Date(node.dateTime)
-      const newLocaleString = date.toLocaleString([],{timeStyle:"long", dateStyle: "medium"})
-      node.innerHTML = newLocaleString;
-    })
+    timeNodes.forEach((node) => {
+      const date = new Date(node.dateTime);
+      const newLocaleString = date.toLocaleString([], {
+        timeStyle: "long",
+        dateStyle: "medium",
+      });
+      node.textContent = newLocaleString;
+    });
+
+    button.remove();
   }
 
-  document.querySelector('#convert-time').addEventListener('click', convertTime)
+  const button = document.querySelector("#convert-time");
+  button.addEventListener("click", convertTime);
 </script>

--- a/src/events.njk
+++ b/src/events.njk
@@ -81,11 +81,12 @@ endif %}
         timeStyle: "long",
         dateStyle: "medium",
       });
-      node.innerHTML = newLocaleString;
+      node.textContent = newLocaleString;
     });
+
+    button.remove();
   }
 
-  document
-    .querySelector("#convert-time")
-    .addEventListener("click", convertTime);
+  const button = document.querySelector("#convert-time");
+  button.addEventListener("click", convertTime);
 </script>


### PR DESCRIPTION
Previously, after clicking the button, you’d be left with the button despite clicking it no longer having an effect. With this patch, the button gets removed as soon as it no longer serves a purpose.