### PR TITLE
docs: fix Discord URL

### DIFF
--- a/src/_includes/how-register.njk
+++ b/src/_includes/how-register.njk
@@ -10,7 +10,7 @@
         href="https://calendar.google.com/calendar/u/0?cid=ZDN1aDgzbzJhMXBsYmt2NGJqMWxoMWQ0YjhAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
         >public calendar</a
       >, in an <a href="#newsletter">email</a> on the day of, and in the
-      <a href="https://www.11ty.dev/news/discord/">11ty discord</a> on the day
+      <a href="https://www.11ty.dev/blog/discord/">11ty discord</a> on the day
       of.
     </p>
   </div>


### PR DESCRIPTION
I noticed this URL was 404'ing and replaced it with a working link.