### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,15 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@11ty/eleventy": "^1.0.0",
+    "@11ty/eleventy": "^3.1.2",
     "@sanity/block-content-to-html": "^2.0.0",
     "@sanity/client": "^2.11.0",
     "groq": "^2.2.6",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^8.4.1",
     "nunjucks-date": "^1.5.0"
+  },
+  "overrides": {
+    "js-yaml": "4.1.1"
   }
 }


### PR DESCRIPTION
Fixes some vulnerabilities. Also upgrades to Eleventy 3 from 1!

Surprisingly, works out-of-the-box, no difference in output!

We can even upgrade to Eleventy 4.0.0-alpha if we like; we'd need to swap out a single `| slug` with a `| slugify` but then that also produces the exact same output once again. So this is an option (and then we don't need the `js-yaml` override).
