### PR TITLE
Remove unused markdown-it packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "@sanity/block-content-to-html": "^2.0.0",
     "@sanity/client": "^2.11.0",
     "groq": "^2.2.6",
-    "markdown-it": "^12.3.2",
-    "markdown-it-anchor": "^8.4.1",
     "nunjucks-date": "^1.5.0"
   },
   "overrides": {


### PR DESCRIPTION
Seems to have been added in 4db2a1f53713850873496957847c2ef78e448524 but it wasn't actually imported anywhere even within that commit. Not sure why it was added, but the build seems to run fine without this, with the same output.